### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/server/PathApi.Server.csproj
+++ b/server/PathApi.Server.csproj
@@ -8,15 +8,15 @@
     <ProjectReference Include="..\proto\PathApi.Proto.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0" />
-    <PackageReference Include="SimpleInjector" Version="4.5.1" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.2" />
+    <PackageReference Include="SimpleInjector" Version="4.6.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="CommandLineParser" Version="2.4.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="CommandLineParser" Version="2.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.110" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.4.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.1" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
Hi@mrazza, I found an issue in the PathApi.Server.csproj:

Packages Microsoft.AspNetCore.SignalR.Client v3.0.0, SimpleInjector v4.5.1, Serilog v2.8.0, CommandLineParser v2.4.3, Newtonsoft.Json v12.0.1 and Microsoft.Azure.ServiceBus v3.4.0 transitively introduce 119 dependencies into path-data’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/path-data.html)), while Microsoft.AspNetCore.SignalR.Client v3.0.2, SimpleInjector v4.6.0, Serilog v2.10.0, CommandLineParser v2.5.0, Newtonsoft.Json v12.0.3 and Microsoft.Azure.ServiceBus v4.2.1 can only introduce 72 dependencies ([see dependency graph after upgrades)](http://202.182.124.107:8000/path-data_after.html).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose