### PR TITLE
Bump Grpc and Grpc-Tools versions

### DIFF
--- a/proto/PathApi.Proto.csproj
+++ b/proto/PathApi.Proto.csproj
@@ -3,12 +3,8 @@
 		<TargetFramework>net5.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Grpc" Version="2.42.0"/>
-    <!--
-      Using an old version of Grpc.Tools as the latest versions mistakening treat WARNINGs as ERRORs
-      during proto compilation. https://github.com/grpc/grpc/issues/27502
-    -->
-		<PackageReference Include="Grpc.Tools" Version="1.19.0"/>
+		<PackageReference Include="Grpc" Version="2.46.5"/>
+		<PackageReference Include="Grpc.Tools" Version="2.50.0"/>
 		<PackageReference Include="Google.Protobuf" Version="3.19.1"/>
 		<PackageReference Include="Google.Protobuf.Tools" Version="3.19.1"/>
 		<PackageReference Include="Google.Api.Gax.Grpc" Version="3.5.0"/>

--- a/server.Tests/PathApi.Server.Tests.csproj
+++ b/server.Tests/PathApi.Server.Tests.csproj
@@ -18,8 +18,8 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
 		<PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
 		<PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
-		<PackageReference Include="Grpc" Version="2.42.0"/>
-		<PackageReference Include="Grpc.Tools" Version="2.42.0"/>
+		<PackageReference Include="Grpc" Version="2.46.5"/>
+		<PackageReference Include="Grpc.Tools" Version="2.50.0"/>
 		<PackageReference Include="Google.Protobuf" Version="3.19.1"/>
 		<PackageReference Include="Google.Protobuf.Tools" Version="3.19.1"/>
 		<PackageReference Include="Google.Api.Gax.Grpc" Version="3.5.0"/>


### PR DESCRIPTION
The issue [1] that was keeping us on an old Grpc-Tools version has been fixed. Bump to the latest versions of Grpc and Grpc-Tools. One notable upgrade this gets us is Apple Silicon support.

[1] https://github.com/grpc/grpc/issues/27502