### PR TITLE
Add typed_config to http_filters in Envoy config

### DIFF
--- a/do/envoy/envoy_config.yaml
+++ b/do/envoy/envoy_config.yaml
@@ -48,7 +48,11 @@ static_resources:
                 always_print_enums_as_ints: false
                 preserve_proto_field_names: false 
           - name: envoy.filters.http.cors
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
   - name: grpc-backend-services 
     connect_timeout: 1.25s


### PR DESCRIPTION
As-of Envoy 1.22 this configuration is necessary for Envoy to start. See e.g. https://github.com/envoyproxy/envoy/issues/20919.